### PR TITLE
use alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.0
+FROM ruby:2.6.4-alpine
 
 LABEL "name"="Publish to Rubygems"
 LABEL "version"="1.0.0"


### PR DESCRIPTION
To make the build process faster use the alpine version

ruby: 2.6.0  => 868MB

![Screenshot from 2019-10-12 22-04-32](https://user-images.githubusercontent.com/6641863/66707156-92e7db80-ed3c-11e9-9e2a-bdb11eea2089.png)

ruby:2.6.4-alpine => 51MB

![Screenshot from 2019-10-12 22-04-49](https://user-images.githubusercontent.com/6641863/66707151-82cffc00-ed3c-11e9-8b45-988d19f175aa.png)

The imgage weight affect the CI time.
