### PR TITLE
run bash script with sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Setting up gem credentials..."
 set +x


### PR DESCRIPTION
Fix error:
```
standard_init_linux.go:211: exec user process caused "no such file or directory"
```
Alpine image don't have shell `bash` use `sh`.