### PR TITLE
Show errors from bundle

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ chmod 0600 ~/.gem/credentials
 set -x
 
 echo "Installing dependencies..."
-bundle install > /dev/null 2>&1
+bundle install > /dev/null
 
 echo "Running gem release task..."
 release_command="${RELEASE_COMMAND:-rake release}"


### PR DESCRIPTION
Allow for an easier debug when bundler errors out. For instance, bundler could error when the gemspec locks a ruby version prior to 2.6, the version set in this project's Dockerfile.