### PR TITLE
Update to ruby 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6
+FROM ruby:2.7
 
 LABEL "name"="Publish to Rubygems"
 LABEL "version"="1.0.0"


### PR DESCRIPTION
If you `gemspec` requires at least ruby 2.7, you won't be able to bundle, and therefore you won't be able to `rake release`. This is happening for one of our projects that had to be updated to 2.7.