### PR TITLE
Fix release script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6
+FROM ruby:2.7
 
 LABEL "name"="Publish to Rubygems"
 LABEL "version"="1.0.0"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "Setting up gem credentials..."
 set +x
@@ -6,16 +6,30 @@ mkdir -p ~/.gem
 
 cat << EOF > ~/.gem/credentials
 ---
-:github: Bearer ${GITHUB_TOKEN}
 :rubygems_api_key: ${RUBYGEMS_API_KEY}
 EOF
 
 chmod 0600 ~/.gem/credentials
 set -x
 
-echo "Installing dependencies..."
-bundle install > /dev/null
+gem_version=$(ruby -r rubygems -e "puts Gem::Specification::load('$(ls *.gemspec)').version")
+echo "::set-output name=gem_version::$gem_version"
 
-echo "Running gem release task..."
-release_command="${RELEASE_COMMAND:-rake release}"
-exec $release_command
+if git fetch origin "refs/tags/v$gem_version" >/dev/null 2>&1
+then
+  echo "Tag 'v$gem_version' already exists"
+  echo "::set-output name=new_version::false"
+else
+  echo "::set-output name=new_version::true"
+
+  git config user.email "${GIT_EMAIL:-automated@example.com}"
+  git config user.name "${GIT_NAME:-Automated Release}"
+
+  echo "Installing dependencies..."
+  gem update bundler
+  bundle install
+
+  echo "Running gem release task..."
+  release_command="${RELEASE_COMMAND:-rake release}"
+  exec $release_command
+fi


### PR DESCRIPTION
The original script had several shortcomings. Namely it did not update bundler
before bundle install, which caused it to fail. Also add check to see if tag
already exists before going through the process, update ruby version to 2.7 and
remove the unnecessary writing of GITHUB_TOKEN to credentials file.