### PR TITLE
Remove exec

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,4 +18,4 @@ bundle install > /dev/null
 
 echo "Running gem release task..."
 release_command="${RELEASE_COMMAND:-rake release}"
-exec $release_command
+$release_command


### PR DESCRIPTION
We usually use Makefile to run a set of commands. To publish a gem we use the command `make gem.push` which runs first `make gem` (to build the gem) and after pushes it. If the exec command is used it runs only the first command and exit the terminal so the next command is never executed.

We recommend not using the exec command. 