### PR TITLE
Entrypoint now `eval`s `RELEASE_COMMAND` then `exit`s

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,4 +18,5 @@ bundle install > /dev/null
 
 echo "Running gem release task..."
 release_command="${RELEASE_COMMAND:-rake release}"
-exec $release_command
+eval "${release_command}"
+exit


### PR DESCRIPTION
This allows a sequence of `RELEASE_COMMAND`s to be used. For example, one can set `RELEASE_COMMAND` to `gem build *.gemspec && gem push *.gem` to publish Gems, where previously with `exec` only the first command in the sequence is executed.