### PR TITLE
Set github workspace as safe in git

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,8 @@ EOF
 chmod 0600 ~/.gem/credentials
 set -x
 
+git config --global --add safe.directory "$(pwd)"
+
 work_directory="${WORKDIR:-.}"
 cd $work_directory
 


### PR DESCRIPTION
Checking directory ownership makes no sense in the context of github actions and causes errors releasing gems.

See example https://github.com/powerhome/power-tools/actions/runs/4127714043/jobs/7131270687

<img width="634" alt="Allow_new_rubocop_versions___103__·_powerhome_power-tools_9e668c5" src="https://user-images.githubusercontent.com/8156/217639925-5f3818c1-ce32-4b01-ad3a-03b90d5867a8.png">
